### PR TITLE
Centralise some "global" pylint exceptions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,4 +2,4 @@
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=fixme, too-many-instance-attributes
+disable=fixme, too-many-instance-attributes, too-many-public-methods, too-few-public-methods, too-many-ancestors

--- a/tinboard/screens/main.py
+++ b/tinboard/screens/main.py
@@ -65,8 +65,6 @@ def filter_binding(name: str) -> Binding:
 class Main(Screen[None]):
     """The main application screen."""
 
-    # pylint:disable=too-many-public-methods
-
     CONTEXT_HELP = """
     ## Application keys and commands
 

--- a/tinboard/suggestions/tags.py
+++ b/tinboard/suggestions/tags.py
@@ -15,8 +15,6 @@ from textual.suggester import Suggester
 class SuggestTags(Suggester):
     """A Textual `Input` suggester that suggests tags."""
 
-    # pylint:disable=too-few-public-methods
-
     def __init__(self, tags: Iterable[str]) -> None:
         """Initialise the suggester.
 

--- a/tinboard/widgets/bookmarks.py
+++ b/tinboard/widgets/bookmarks.py
@@ -152,10 +152,8 @@ class Bookmark(Option):
 
 
 ##############################################################################
-class Bookmarks(OptionListEx):  # pylint:disable = too-many-instance-attributes
+class Bookmarks(OptionListEx):
     """The list of bookmarks."""
-
-    # pylint:disable = too-many-public-methods
 
     CONTEXT_HELP = """
     ## Bookmarks keys and commands

--- a/tinboard/widgets/tags.py
+++ b/tinboard/widgets/tags.py
@@ -122,7 +122,7 @@ class Tags(OptionListEx):
 
 
 ##############################################################################
-class TagsMenu(Tags):  # pylint:disable=too-many-ancestors
+class TagsMenu(Tags):
     """A version of `Tags` to use as part of the main menu."""
 
     CONTEXT_HELP = f"{Tags.CONTEXT_HELP}| <kbd>c</kbd> | Clear any active tag filter. |"
@@ -135,7 +135,7 @@ class TagsMenu(Tags):  # pylint:disable=too-many-ancestors
 
 
 ##############################################################################
-class InlineTags(Tags):  # pylint:disable=too-many-ancestors
+class InlineTags(Tags):
     """A version of the `Tags` widget intended to embed in another."""
 
     DEFAULT_CSS = """


### PR DESCRIPTION
Starting to get too many instances of pylint exceptions through the code, that all relate to single central reasonable exceptions. This clears that up.