### PR TITLE
Add the ability to sort the tags menu by bookmark count

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 **Released: WiP**
 
 - Decluttered the footer in most cases; use of <kbd>F1</kbd> emphasised.
+- Added the ability to sort the tags menu by bookmark count.
 
 ## v0.2.0
 

--- a/tinboard/data/config.py
+++ b/tinboard/data/config.py
@@ -23,6 +23,9 @@ class Configuration:
     details_visible: bool = True
     """Show the details pane be visible?"""
 
+    sort_tags_by_count: bool = False
+    """Should the tag menu sort on count?"""
+
 
 ##############################################################################
 def configuration_file() -> Path:


### PR DESCRIPTION
Adds the ability to sort the tags menu by bookmark count, or by name; also makes this a "sticky" setting.