### PR TITLE
Simplify the search dialog

### DIFF
--- a/tinboard/screens/search_input.py
+++ b/tinboard/screens/search_input.py
@@ -4,7 +4,6 @@
 # Textual imports.
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Input
 
@@ -18,18 +17,11 @@ class SearchInput(ModalScreen[str]):
         align: center middle;
     }
 
-    SearchInput Vertical {
+    SearchInput Input, SearchInput Input:focus {
         border: round $accent;
         width: 60%;
-        height: auto;
-        background: $surface;
-    }
-
-    SearchInput Input, SearchInput Input:focus {
-        margin: 0;
         padding: 1;
-        border: none;
-        background: $surface;
+        height: auto;
     }
     """
 
@@ -37,10 +29,7 @@ class SearchInput(ModalScreen[str]):
 
     def compose(self) -> ComposeResult:
         """Compose the input dialog."""
-        with Vertical():
-            yield Input(
-                placeholder="Case-insensitive text to look for in the bookmarks"
-            )
+        yield Input(placeholder="Case-insensitive text to look for in the bookmarks")
 
     @on(Input.Submitted)
     def search(self) -> None:


### PR DESCRIPTION
I think I'd started it out wrapped in a Vertical, assuming I was going to add some other options (case sensitivity, that sort of thing). As it turns out, I went with a "just go find everything I can" approach, and I prefer it.

So this reduces the dialog to the bare minimum of widgets and code, for the exact same interface.