### PR TITLE
Default a new bookmark's URL to clipboard content

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 **Released: WiP**
 
 - Added the ability to copy a bookmark's URL to the clipboard.
+- URL field will populate with any URL in the clipboard when adding a new
+  bookmark.
 
 ## v0.3.0
 


### PR DESCRIPTION
When adding a new bookmark, if it's possible to pull text from the clipboard, and if it parses as a URL, and if the scheme is one of http or https (I don't think there's anything about Pinboard that restricts to those schemes, but this feels like a sensible first check), and if the user hasn't managed to start typing already, populate the URL field with that clipboard content.