### PR TITLE
Centralise the clipboard copying code

### DIFF
--- a/tinboard/commands/__init__.py
+++ b/tinboard/commands/__init__.py
@@ -2,7 +2,7 @@
 
 ##############################################################################
 # Local imports.
-from .bookmark_modification import BookmarkModificationCommands
+from .bookmarks import BookmarkCommands
 from .core_commands import CoreCommands
 from .core_filters import CoreFilteringCommands
 from .tags import TagCommands
@@ -10,7 +10,7 @@ from .tags import TagCommands
 ##############################################################################
 # Public symbols.
 __all__ = [
-    "BookmarkModificationCommands",
+    "BookmarkCommands",
     "CoreCommands",
     "CoreFilteringCommands",
     "TagCommands",

--- a/tinboard/commands/bookmarks.py
+++ b/tinboard/commands/bookmarks.py
@@ -1,4 +1,4 @@
-"""Commands related to modifying bookmarks."""
+"""Commands related to the list of bookmarks."""
 
 ##############################################################################
 # Python imports.
@@ -20,8 +20,8 @@ from ..messages import (
 
 
 ##############################################################################
-class BookmarkModificationCommands(Provider):
-    """A source of commands for making modifications to bookmarks."""
+class BookmarkCommands(Provider):
+    """A source of commands for doing things with bookmarks."""
 
     async def search(self, query: str) -> Hits:
         """Handle a request to search for commands that match the query.
@@ -61,4 +61,4 @@ class BookmarkModificationCommands(Provider):
                 )
 
 
-### bookmark_modification.py ends here
+### bookmarks.py ends here

--- a/tinboard/commands/bookmarks.py
+++ b/tinboard/commands/bookmarks.py
@@ -12,6 +12,7 @@ from textual.command import Hit, Hits, Provider
 # Local imports.
 from ..messages import (
     AddBookmark,
+    CopyBookmarkURL,
     EditBookmark,
     DeleteBookmark,
     ToggleBookmarkPublic,
@@ -38,6 +39,11 @@ class BookmarkCommands(Provider):
                 "Add a new bookmark",
                 AddBookmark,
                 "Add a new bookmark to your bookmark collection",
+            ),
+            (
+                "Copy to clipboard",
+                CopyBookmarkURL,
+                "Copy the URL for the current bookmark to the clipboard",
             ),
             ("Edit bookmark", EditBookmark, "Edit the current bookmark"),
             (

--- a/tinboard/messages/__init__.py
+++ b/tinboard/messages/__init__.py
@@ -4,6 +4,7 @@
 # Local imports.
 from .commands import (
     AddBookmark,
+    CopyBookmarkURL,
     EditBookmark,
     DeleteBookmark,
     ToggleBookmarkRead,
@@ -16,6 +17,7 @@ from .tags import ClearTags, ShowAlsoTaggedWith, ShowTaggedWith
 __all__ = [
     "AddBookmark",
     "ClearTags",
+    "CopyBookmarkURL",
     "EditBookmark",
     "DeleteBookmark",
     "ShowAlsoTaggedWith",

--- a/tinboard/messages/commands.py
+++ b/tinboard/messages/commands.py
@@ -35,4 +35,9 @@ class ToggleBookmarkPublic(Command):
     """Toggle the public status of the current bookmark."""
 
 
+##############################################################################
+class CopyBookmarkURL(Command):
+    """Copy the URL for the bookmark to the clipboard."""
+
+
 ### commands.py ends here

--- a/tinboard/screens/main.py
+++ b/tinboard/screens/main.py
@@ -6,6 +6,10 @@ from functools import partial
 from webbrowser import open as open_url
 
 ##############################################################################
+# Pyperclip imports.
+from pyperclip import copy as to_clipboard, PyperclipException
+
+##############################################################################
 # Textual imports.
 from textual import on, work
 from textual.app import ComposeResult
@@ -36,6 +40,7 @@ from ..data import (
 )
 from ..messages import (
     AddBookmark,
+    CopyBookmarkURL,
     ClearTags,
     DeleteBookmark,
     EditBookmark,
@@ -471,6 +476,22 @@ class Main(Screen[None]):
                     title="Save Error",
                     severity="error",
                     timeout=8,
+                )
+
+    @on(CopyBookmarkURL)
+    def copy_bookmark_to_clipboard(self) -> None:
+        """Copy the currently-highlighted bookmark to the clipboard."""
+        if (bookmark := self.query_one(Bookmarks).current_bookmark) is None:
+            self.app.bell()
+        elif bookmark.data.href:
+            try:
+                to_clipboard(bookmark.data.href)
+                self.notify("URL copied to the clipboard")
+            except PyperclipException:
+                self.app.bell()
+                self.notify(
+                    "Clipboard support not available in your environment.",
+                    severity="error",
                 )
 
     @on(AddBookmark)

--- a/tinboard/screens/main.py
+++ b/tinboard/screens/main.py
@@ -26,7 +26,7 @@ from .confirm import Confirm
 from .help import Help
 from .search_input import SearchInput
 from ..commands import (
-    BookmarkModificationCommands,
+    BookmarkCommands,
     CoreCommands,
     CoreFilteringCommands,
     TagCommands,
@@ -99,7 +99,7 @@ class Main(Screen[None]):
     TITLE = f"Tinboard v{__version__}"
     SUB_TITLE = "A pinboard.in client"
     COMMANDS = {
-        BookmarkModificationCommands,
+        BookmarkCommands,
         CoreCommands,
         CoreFilteringCommands,
         TagCommands,

--- a/tinboard/widgets/bookmarks.py
+++ b/tinboard/widgets/bookmarks.py
@@ -11,10 +11,6 @@ from webbrowser import open as open_url
 from typing_extensions import Final, Self
 
 ##############################################################################
-# Pyperclip imports.
-from pyperclip import copy as to_clipboard, PyperclipException
-
-##############################################################################
 # pytz imports.
 from pytz import UTC
 
@@ -40,6 +36,7 @@ from rich.table import Table
 # Local imports.
 from ..messages import (
     AddBookmark,
+    CopyBookmarkURL,
     EditBookmark,
     DeleteBookmark,
     ToggleBookmarkPublic,
@@ -244,17 +241,7 @@ class Bookmarks(OptionListEx):
 
     def action_copy(self) -> None:
         """Copy the URL of the current bookmark to the clipboard."""
-        if (bookmark := self.highlighted_bookmark) is not None:
-            if bookmark.data.href:
-                try:
-                    to_clipboard(bookmark.data.href)
-                    self.notify("URL copied to the clipboard")
-                except PyperclipException:
-                    self.app.bell()
-                    self.notify(
-                        "Clipboard support not available in your environment.",
-                        severity="error",
-                    )
+        self.post_message(CopyBookmarkURL())
 
     def action_new(self) -> None:
         """Post the new bookmark command."""

--- a/tinboard/widgets/bookmarks.py
+++ b/tinboard/widgets/bookmarks.py
@@ -164,7 +164,7 @@ class Bookmarks(OptionListEx):
     | Key | Command | Description |
     | - | - | - |
     | <kbd>Enter</kbd> | | Visit the current bookmark. |
-    | <kbd>c</kbd> |  | Copy the URL of the bookmark to the clipboard. |
+    | <kbd>c</kbd> | `Copy to clipboard` | Copy the URL of the bookmark to the clipboard. |
     | <kbd>n</kbd> | `Add a new bookmark` | Create a new bookmark. |
     | <kbd>e</kbd> | `Edit bookmark` | Edit the currently-highlighted bookmark. |
     | <kbd>d</kbd> | `Delete bookmark` | Delete the currently-highlighted bookmark. |

--- a/tinboard/widgets/details.py
+++ b/tinboard/widgets/details.py
@@ -9,10 +9,6 @@ from webbrowser import open as open_url
 from humanize import naturaltime
 
 ##############################################################################
-# Pyperclip imports.
-from pyperclip import copy as to_clipboard, PyperclipException
-
-##############################################################################
 # Textual imports.
 from textual import on
 from textual.app import ComposeResult
@@ -24,7 +20,12 @@ from textual.widgets import Label
 
 ##############################################################################
 # Local imports.
-from ..messages import EditBookmark, ToggleBookmarkPublic, ToggleBookmarkRead
+from ..messages import (
+    CopyBookmarkURL,
+    EditBookmark,
+    ToggleBookmarkPublic,
+    ToggleBookmarkRead,
+)
 from .bookmarks import Bookmark
 from .tags import InlineTags
 
@@ -184,17 +185,7 @@ class Details(VerticalScroll):
 
     def action_copy(self) -> None:
         """Copy the URL of the bookmark to the clipboard."""
-        if self.bookmark is not None:
-            if self.bookmark.data.href:
-                try:
-                    to_clipboard(self.bookmark.data.href)
-                    self.notify("URL copied to the clipboard")
-                except PyperclipException:
-                    self.app.bell()
-                    self.notify(
-                        "Clipboard support not available in your environment.",
-                        severity="error",
-                    )
+        self.post_message(CopyBookmarkURL())
 
 
 ### details.py ends here


### PR DESCRIPTION
Moves the code for copying to the clipboard onto the main screen, as a message handler, and then turns the request to copy into a command message.

Also adds a command palette command for copying to the clipboard.