### PR TITLE
Allow escape to exit from the "top level"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Tinboard ChangeLog
 
+## WiP
+
+**Released: WiP**
+
+- Pressing <kbd>Escape</kbd> when in the "top-level" widget (so in the
+  filters) now exits the application.
+
 ## v0.8.0
 
 **Released: 2024-02-18**

--- a/tinboard/screens/main.py
+++ b/tinboard/screens/main.py
@@ -376,6 +376,8 @@ class Main(Screen[None]):
             self.query_one(Bookmarks).focus()
         elif isinstance(self.screen.focused, (Bookmarks, TagsMenu)):
             self.query_one(Filters).focus()
+        elif isinstance(self.screen.focused, Filters):
+            self.app.exit()
 
     @on(Filters.ShowAll)
     def action_show_all(self) -> None:

--- a/tinboard/widgets/filters.py
+++ b/tinboard/widgets/filters.py
@@ -115,6 +115,11 @@ class Filters(OptionListEx):
             [Option(self._prompt(option), id=option.lower()) for option in self.OPTIONS]
         )
 
+    def on_focus(self) -> None:
+        """Try and ensure an option is highlighted when we get focus."""
+        if self.highlighted is None and self.option_count:
+            self.highlighted = 0
+
     class CoreFilter(Message):
         """Base class for the core filters."""
 


### PR DESCRIPTION
In many apps I write I <kbd>escape</kbd> to be a progressive way of getting out of an application; but it wasn't done here. This makes it so that if you press <kbd>escape</kbd> in the `Filters` menu, the application will exit.
