### PR TITLE
Add tag command discovery hits to the command palette

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Tinboard ChangeLog
 
+## WiP
+
+**Released: WiP**
+
+- Added tag command discovery hits to the command palette (that is, the
+  command palette now pre-populates with all tag-based commands when first
+  opened).
+
 ## v0.9.0
 
 **Released: 2024-02-29**

--- a/tinboard/commands/tags.py
+++ b/tinboard/commands/tags.py
@@ -6,7 +6,7 @@ from functools import partial
 
 ##############################################################################
 # Textual imports.
-from textual.command import Hit, Hits, Provider
+from textual.command import DiscoveryHit, Hit, Hits, Provider
 
 ##############################################################################
 # Local imports.
@@ -19,6 +19,33 @@ class TagCommands(Provider):
 
     current_tags: list[str] = []
     """The current set of tags to draw on when setting up the commands."""
+
+    async def discover(self) -> Hits:
+        """Handle a request to discover commands.
+
+        Yields:
+            Command discovery hits for the command palette.
+        """
+
+        # Create commands for all the tags.
+        for tag in self.current_tags:
+            for prefix, message in (
+                ("", ShowTaggedWith),
+                ("Also", ShowAlsoTaggedWith),
+            ):
+                full_command = f"{prefix} tagged {tag}".strip().capitalize()
+                yield DiscoveryHit(
+                    full_command,
+                    partial(self.screen.post_message, message(tag)),
+                    help=f"Show all bookmarks that are {full_command.lower()}",
+                )
+
+        # Also add a command for clearing tags.
+        yield DiscoveryHit(
+            "Clear tag filter",
+            partial(self.screen.post_message, ClearTags()),
+            help="Clear any current tag-based filtering",
+        )
 
     async def search(self, query: str) -> Hits:
         """Handle a request to search for commands that match the query.


### PR DESCRIPTION
This means that when the command palette is first opened all of the tag-based commands are already there to be seen.