### PR TITLE
Add bookmark command discovery hits to the command palette

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@
 - Added filter command discovery hits to the command palette (that is, the
   command palette now pre-populates with all filter-based commands when
   first opened).
+- Added bookmark command discovery hits to the command palette (that is, the
+  command palette now pre-populates with all bookmark-based commands when
+  first opened).
 
 ## v0.9.0
 

--- a/tinboard/commands/bookmarks.py
+++ b/tinboard/commands/bookmarks.py
@@ -6,12 +6,17 @@ from functools import partial
 
 ##############################################################################
 # Textual imports.
-from textual.command import Hit, Hits, Provider
+from textual.command import DiscoveryHit, Hit, Hits, Provider
+
+##############################################################################
+# Backward-compatible typing.
+from typing_extensions import Final
 
 ##############################################################################
 # Local imports.
 from ..messages import (
     AddBookmark,
+    Command,
     CopyBookmarkURL,
     DeleteBookmark,
     EditBookmark,
@@ -24,6 +29,44 @@ from ..messages import (
 class BookmarkCommands(Provider):
     """A source of commands for doing things with bookmarks."""
 
+    COMMANDS: Final[tuple[tuple[str, type[Command], str], ...]] = (
+        (
+            "Add a new bookmark",
+            AddBookmark,
+            "Add a new bookmark to your bookmark collection",
+        ),
+        (
+            "Copy to clipboard",
+            CopyBookmarkURL,
+            "Copy the URL for the current bookmark to the clipboard",
+        ),
+        ("Edit bookmark", EditBookmark, "Edit the current bookmark"),
+        (
+            "Toggle public/private",
+            ToggleBookmarkPublic,
+            "Toggle the current bookmark's public/private status",
+        ),
+        ("Delete bookmark", DeleteBookmark, "Delete the current bookmark"),
+        (
+            "Toggle read/unread",
+            ToggleBookmarkRead,
+            "Toggle the current bookmark's read/unread status",
+        ),
+    )
+
+    async def discover(self) -> Hits:
+        """Handle a request to discover commands.
+
+        Yields:
+            Command discovery hits for the command palette.
+        """
+        for command, message, help_text in self.COMMANDS:
+            yield DiscoveryHit(
+                command,
+                partial(self.screen.post_message, message()),
+                help=help_text,
+            )
+
     async def search(self, query: str) -> Hits:
         """Handle a request to search for commands that match the query.
 
@@ -34,30 +77,7 @@ class BookmarkCommands(Provider):
             Command hits for the command palette.
         """
         matcher = self.matcher(query)
-        for command, message, help_text in (
-            (
-                "Add a new bookmark",
-                AddBookmark,
-                "Add a new bookmark to your bookmark collection",
-            ),
-            (
-                "Copy to clipboard",
-                CopyBookmarkURL,
-                "Copy the URL for the current bookmark to the clipboard",
-            ),
-            ("Edit bookmark", EditBookmark, "Edit the current bookmark"),
-            (
-                "Toggle public/private",
-                ToggleBookmarkPublic,
-                "Toggle the current bookmark's public/private status",
-            ),
-            ("Delete bookmark", DeleteBookmark, "Delete the current bookmark"),
-            (
-                "Toggle read/unread",
-                ToggleBookmarkRead,
-                "Toggle the current bookmark's read/unread status",
-            ),
-        ):
+        for command, message, help_text in self.COMMANDS:
             if match := matcher.match(command):
                 yield Hit(
                     match,

--- a/tinboard/messages/__init__.py
+++ b/tinboard/messages/__init__.py
@@ -4,6 +4,7 @@
 # Local imports.
 from .commands import (
     AddBookmark,
+    Command,
     CopyBookmarkURL,
     DeleteBookmark,
     EditBookmark,
@@ -17,6 +18,7 @@ from .tags import ClearTags, ShowAlsoTaggedWith, ShowTaggedWith
 __all__ = [
     "AddBookmark",
     "ClearTags",
+    "Command",
     "CopyBookmarkURL",
     "EditBookmark",
     "DeleteBookmark",


### PR DESCRIPTION
This means that when the command palette is first opened all of the bookmark-based commands are already there to be seen.