### PR TITLE
Add core command discovery hits to the command palette

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,9 @@
 - Added bookmark command discovery hits to the command palette (that is, the
   command palette now pre-populates with all bookmark-based commands when
   first opened).
+- Added core command discovery hits to the command palette (that is, the
+  command palette now pre-populates with all core commands when first
+  opened).
 
 ## v0.9.0
 

--- a/tinboard/commands/core_commands.py
+++ b/tinboard/commands/core_commands.py
@@ -6,12 +6,50 @@ from functools import partial
 
 ##############################################################################
 # Textual imports.
-from textual.command import Hit, Hits, Provider
+from textual.command import DiscoveryHit, Hit, Hits, Provider
+
+##############################################################################
+# Backward-compatible typing.
+from typing_extensions import Final
 
 
 ##############################################################################
 class CoreCommands(Provider):
     """A source of commands for invoking the main application commands."""
+
+    COMMANDS: Final[tuple[tuple[str, str, str], ...]] = (
+        ("Help", "help", "Show the main help screen"),
+        ("Visit Pinboard", "goto_pinboard", "Visit the Pinboard website"),
+        (
+            "Redownload/refresh bookmarks",
+            "redownload",
+            "Download a full fresh copy of your bookmarks from Pinboard",
+        ),
+        ("Search", "search", "Search for text in the currently-shown bookmarks"),
+        (
+            "Logout",
+            "logout",
+            "Forget your Pinboard API token and remove the local copies of all bookmarks.",
+        ),
+        (
+            "Toggle details",
+            "toggle_details",
+            "Toggle the display of the details of the highlighted bookmark.",
+        ),
+    )
+
+    async def discover(self) -> Hits:
+        """Handle a request to discover commands.
+
+        Yields:
+            Command discovery hits for the command palette.
+        """
+        for command, action, help_text in self.COMMANDS:
+            yield DiscoveryHit(
+                command,
+                partial(self.screen.run_action, action),
+                help=help_text,
+            )
 
     async def search(self, query: str) -> Hits:
         """Handle a request to search for commands that match the query.
@@ -23,26 +61,7 @@ class CoreCommands(Provider):
             Command hits for the command palette.
         """
         matcher = self.matcher(query)
-        for command, action, help_text in (
-            ("Help", "help", "Show the main help screen"),
-            ("Visit Pinboard", "goto_pinboard", "Visit the Pinboard website"),
-            (
-                "Redownload/refresh bookmarks",
-                "redownload",
-                "Download a full fresh copy of your bookmarks from Pinboard",
-            ),
-            ("Search", "search", "Search for text in the currently-shown bookmarks"),
-            (
-                "Logout",
-                "logout",
-                "Forget your Pinboard API token and remove the local copies of all bookmarks.",
-            ),
-            (
-                "Toggle details",
-                "toggle_details",
-                "Toggle the display of the details of the highlighted bookmark.",
-            ),
-        ):
+        for command, action, help_text in self.COMMANDS:
             if match := matcher.match(command):
                 yield Hit(
                     match,


### PR DESCRIPTION
This means that when the command palette is first opened all of the core commands are already there to be seen.