### PR TITLE
Add a default filter command line option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@
 **Released: WiP**
 
 - Updated to Textual v0.55.1
+- Added a `--help` command line argument.
+- Added a `--version` command line argument.
+- Added a `--filter` command line argument.
 
 ## v0.10.0
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ black  := $(run) black
 # Run the app.
 .PHONY: run
 run:
-	$(python) -m $(lib)
+	$(python) -m $(lib) --filter public
 
 .PHONY: debug
 debug:

--- a/tinboard/__main__.py
+++ b/tinboard/__main__.py
@@ -1,15 +1,60 @@
 """The main entry point for the application."""
 
 ##############################################################################
+# Python imports.
+from argparse import ArgumentParser, Namespace
+
+##############################################################################
+# Textual imports.
+from textual import __version__ as __textual_version__
+
+##############################################################################
 # Local imports.
+from . import __version__
 from .app import Tinboard
 from .data import ExitStates
+from .widgets import Filters
+
+
+##############################################################################
+def get_args() -> Namespace:
+    """Get the command line arguments.
+
+    Returns:
+        The parsed command line arguments.
+    """
+    parser = ArgumentParser(
+        prog="tinboard",
+        description="A terminal-based client for Pinboard.",
+        epilog=f"v{__version__}",
+    )
+
+    # Add --filter
+    parser.add_argument(
+        "-f",
+        "--filter",
+        choices=Filters.core_filter_names(),
+        default=Filters.core_filter_names()[0],
+        help="Set the default filter to use on startup",
+    )
+
+    # Add --version
+    parser.add_argument(
+        "-v",
+        "--version",
+        help="Show version information.",
+        action="version",
+        version=f"%(prog)s {__version__} (Textual v{__textual_version__})",
+    )
+
+    # Return the arguments.
+    return parser.parse_args()
 
 
 ##############################################################################
 def run() -> None:
     """Run the application."""
-    state = Tinboard().run()
+    state = Tinboard(get_args().filter).run()
     if state == ExitStates.TOKEN_FORGOTTEN:
         if Tinboard.environmental_token():
             print(

--- a/tinboard/app.py
+++ b/tinboard/app.py
@@ -17,6 +17,7 @@ from textual.binding import Binding
 # Local imports.
 from .data import ExitStates, load_configuration, save_configuration, token_file
 from .screens import Main, TokenInput
+from .widgets.filters import Filters
 
 
 ##############################################################################
@@ -28,10 +29,20 @@ class Tinboard(App[ExitStates]):
         Binding("ctrl+p", "command_palette", priority=True),
     ]
 
-    def __init__(self) -> None:
-        """Initialise the application."""
+    def __init__(self, initial_filter: str | None = None) -> None:
+        """Initialise the application.
+
+        Args:
+            initial_filter: The initial filter to apply when starting up.
+        """
         super().__init__()
         self.dark = load_configuration().dark_mode
+        self._initial_filter: set[type[Filters.CoreFilter]] = (
+            set()
+            if initial_filter is None
+            else {Filters.core_filter_type(initial_filter)}
+        )
+        """The initial filter to apply when showing the main screen."""
 
     def token_bounce(self, token: str | None) -> None:
         """Handle the result of asking the user for their API token.
@@ -79,7 +90,7 @@ class Tinboard(App[ExitStates]):
             once the token has been acquired.
         """
         if token := self.api_token:
-            self.push_screen(Main(token))
+            self.push_screen(Main(token, self._initial_filter))
         else:
             self.push_screen(TokenInput(), callback=self.token_bounce)
 

--- a/tinboard/screens/main.py
+++ b/tinboard/screens/main.py
@@ -203,14 +203,22 @@ class Main(Screen[None]):
         Binding("/", "search"),
     ]
 
-    def __init__(self, api_token: str) -> None:
+    def __init__(
+        self,
+        api_token: str,
+        default_filters: set[type[Filters.CoreFilter]] | None = None,
+    ) -> None:
         """Initialise the main screen.
 
         Args:
             api_token: The Pinboard API token.
+            default_filters: Any default filters to apply on startup.
         """
         super().__init__()
         self._api = API(api_token)
+        """The Pinboard API client."""
+        self._default_filters: set[type[Filters.CoreFilter]] = default_filters or set()
+        """The default filters to use on startup."""
 
     def compose(self) -> ComposeResult:
         """Lay out the content of the screen."""
@@ -231,6 +239,8 @@ class Main(Screen[None]):
         self.query_one(Bookmarks).loading = True
         self.query_one(TagsMenu).sort_by_count = configuration.sort_tags_by_count
         self.load_bookmarks()
+        for default_filter in self._default_filters:
+            self.post_message(default_filter())
 
     @work(thread=True)
     def load_bookmarks(self) -> None:

--- a/tinboard/widgets/filters.py
+++ b/tinboard/widgets/filters.py
@@ -144,6 +144,38 @@ class Filters(OptionListEx):
     class ShowUntagged(CoreFilter):
         """Show the bookmarks that have no tags."""
 
+    _CORE_FILTERS: Final[dict[str, type[CoreFilter]]] = {
+        "all": ShowAll,
+        "unread": ShowUnread,
+        "read": ShowRead,
+        "public": ShowPublic,
+        "private": ShowPrivate,
+        "tagged": ShowTagged,
+        "untagged": ShowUntagged,
+    }
+    """The core filters and their message mappings."""
+
+    @classmethod
+    def core_filter_names(cls) -> list[str]:
+        """The names for the core filters.
+
+        Return:
+            The names of the core filters.
+        """
+        return list(cls._CORE_FILTERS)
+
+    @classmethod
+    def core_filter_type(cls, name: str) -> type[CoreFilter]:
+        """Get a core filter message type based off its name.
+
+        Args:
+            name: The name of the filter.
+
+        Returns:
+            A message type to request that filter be used.
+        """
+        return cls._CORE_FILTERS[name.lower()]
+
     @classmethod
     def core_filter_message(cls, name: str) -> CoreFilter:
         """Get a core filter message based off its name.
@@ -154,15 +186,7 @@ class Filters(OptionListEx):
         Returns:
             A message to request that filter be used.
         """
-        return {
-            "all": cls.ShowAll,
-            "unread": cls.ShowUnread,
-            "read": cls.ShowRead,
-            "public": cls.ShowPublic,
-            "private": cls.ShowPrivate,
-            "tagged": cls.ShowTagged,
-            "untagged": cls.ShowUntagged,
-        }[name.lower()]()
+        return cls.core_filter_type(name)()
 
     @on(OptionListEx.OptionSelected)
     def handle_selection(self, event: OptionListEx.OptionSelected) -> None:


### PR DESCRIPTION
This adds a `--filter` command line option so that Tinboard can be started up with a specific filter in place. In doing so I also add `--version` and `--help` options.

This also changes the `Makefile` so that the default view is public bookmarks; this means I don't have to worry so much about personal stuff appear on screen if I'm streaming some development of Tinboard.