### PR TITLE
Add the ability to add a bookmark "inline" in the terminal

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
 - Added a `--help` command line argument.
 - Added a `--version` command line argument.
 - Added a `--filter` command line argument.
+- Added a `add` command line command, which shows the bookmark addition
+  screen "inline" in the terminal, allows adding a new bookmark, then exits.
 
 ## v0.10.0
 

--- a/tinboard/__main__.py
+++ b/tinboard/__main__.py
@@ -63,7 +63,9 @@ def get_args() -> Namespace:
 def run() -> None:
     """Run the application."""
     args = get_args()
-    state = Tinboard(args.filter).run(inline=args.command == "add")
+    inline_add = args.command == "add"
+    Tinboard.ENABLE_COMMAND_PALETTE = not inline_add
+    state = Tinboard(args.filter).run(inline=inline_add)
     if state == ExitStates.TOKEN_FORGOTTEN:
         if Tinboard.environmental_token():
             print(

--- a/tinboard/__main__.py
+++ b/tinboard/__main__.py
@@ -63,9 +63,7 @@ def get_args() -> Namespace:
 def run() -> None:
     """Run the application."""
     args = get_args()
-    inline_add = args.command == "add"
-    Tinboard.ENABLE_COMMAND_PALETTE = not inline_add
-    state = Tinboard(args.filter).run(inline=inline_add)
+    state = Tinboard(args.filter).run(inline=args.command == "add")
     if state == ExitStates.TOKEN_FORGOTTEN:
         if Tinboard.environmental_token():
             print(

--- a/tinboard/__main__.py
+++ b/tinboard/__main__.py
@@ -65,6 +65,8 @@ def run() -> None:
             print("The locally-held copy of your API token has been removed.")
     elif state == ExitStates.TOKEN_NEEDED:
         print("An API token is needed to be able to connect to Pinboard.")
+    elif state == ExitStates.INLINE_SAVE_ERROR:
+        print("There was an error writing the bookmark to the Pinboard server.")
 
 
 ##############################################################################

--- a/tinboard/__main__.py
+++ b/tinboard/__main__.py
@@ -29,6 +29,14 @@ def get_args() -> Namespace:
         epilog=f"v{__version__}",
     )
 
+    # Add the add command
+    parser.add_argument(
+        "command",
+        choices=["add"],
+        nargs="?",
+        help="A command to modify the startup behaviour",
+    )
+
     # Add --filter
     parser.add_argument(
         "-f",
@@ -54,7 +62,8 @@ def get_args() -> Namespace:
 ##############################################################################
 def run() -> None:
     """Run the application."""
-    state = Tinboard(get_args().filter).run()
+    args = get_args()
+    state = Tinboard(args.filter).run(inline=args.command == "add")
     if state == ExitStates.TOKEN_FORGOTTEN:
         if Tinboard.environmental_token():
             print(

--- a/tinboard/app.py
+++ b/tinboard/app.py
@@ -53,7 +53,7 @@ class Tinboard(App[ExitStates]):
         """
         if token:
             token_file().write_text(token, encoding="utf-8")
-            self.push_screen(Main(token))
+            self.push_screen(Main(API(token)))
         else:
             self.exit(ExitStates.TOKEN_NEEDED)
 

--- a/tinboard/app.py
+++ b/tinboard/app.py
@@ -16,6 +16,7 @@ from textual.binding import Binding
 ##############################################################################
 # Local imports.
 from .data import ExitStates, load_configuration, save_configuration, token_file
+from .pinboard import API
 from .screens import Main, TokenInput
 from .widgets.filters import Filters
 
@@ -90,7 +91,7 @@ class Tinboard(App[ExitStates]):
             once the token has been acquired.
         """
         if token := self.api_token:
-            self.push_screen(Main(token, self._initial_filter))
+            self.push_screen(Main(API(token), self._initial_filter))
         else:
             self.push_screen(TokenInput(), callback=self.token_bounce)
 

--- a/tinboard/app.py
+++ b/tinboard/app.py
@@ -106,6 +106,7 @@ class Tinboard(App[ExitStates]):
         """
         if token := self.api_token:
             if self.is_inline:
+                self.use_command_palette = False
                 self.push_screen(BookmarkInput(API(token)), callback=self.inline_add)
             else:
                 self.push_screen(Main(API(token), self._initial_filter))

--- a/tinboard/app.py
+++ b/tinboard/app.py
@@ -106,9 +106,15 @@ class Tinboard(App[ExitStates]):
         """
         if token := self.api_token:
             if self.is_inline:
+                # If we're running as an inline application, that means we
+                # should simply be showing the bookmark input screen for
+                # quick input. Note disabling the command palette too, which
+                # has problems with inline mode.
                 self.use_command_palette = False
                 self.push_screen(BookmarkInput(API(token)), callback=self.inline_add)
             else:
+                # We're not in inline mode so we'll show the normal
+                # application screen.
                 self.push_screen(Main(API(token), self._initial_filter))
         else:
             self.push_screen(TokenInput(), callback=self.token_bounce)

--- a/tinboard/app.py
+++ b/tinboard/app.py
@@ -53,7 +53,7 @@ class Tinboard(App[ExitStates]):
         """
         if token:
             token_file().write_text(token, encoding="utf-8")
-            self.push_screen(Main(API(token)))
+            self.push_screen(Main(API(token), self._initial_filter))
         else:
             self.exit(ExitStates.TOKEN_NEEDED)
 

--- a/tinboard/data/exit_states.py
+++ b/tinboard/data/exit_states.py
@@ -18,5 +18,8 @@ class ExitStates(Enum):
     TOKEN_FORGOTTEN = 2
     """The application exited because the user forgot the token."""
 
+    INLINE_SAVE_ERROR = 3
+    """There was an error with an inline save."""
+
 
 ### exit_states.py ends here

--- a/tinboard/screens/bookmark_input.py
+++ b/tinboard/screens/bookmark_input.py
@@ -44,6 +44,11 @@ class BookmarkInput(ModalScreen[BookmarkData | None]):
             background: $surface;
             border: panel $primary;
             border-title-color: $accent;
+
+            &:inline {
+                width: 100%;
+                border: none;
+            }
         }
 
         #description {

--- a/tinboard/screens/main.py
+++ b/tinboard/screens/main.py
@@ -205,17 +205,17 @@ class Main(Screen[None]):
 
     def __init__(
         self,
-        api_token: str,
+        api: API,
         default_filters: set[type[Filters.CoreFilter]] | None = None,
     ) -> None:
         """Initialise the main screen.
 
         Args:
-            api_token: The Pinboard API token.
+            api: The Pinboard API.
             default_filters: Any default filters to apply on startup.
         """
         super().__init__()
-        self._api = API(api_token)
+        self._api = api
         """The Pinboard API client."""
         self._default_filters: set[type[Filters.CoreFilter]] = default_filters or set()
         """The default filters to use on startup."""


### PR DESCRIPTION
An experiment with Textual's newly-added inline mode. Adds a `add` command to the command line of `tinboard`, which when used will pop up a "inline" version of the bookmark entry/edit screen, allow the addition of the bookmark, and then exit back to the command line.

![Screenshot 2024-04-06 at 09 14 51](https://github.com/davep/tinboard/assets/28237/23cc94d4-6fad-40e1-bab2-79b43e094875)

To really fully work this will need some more changes to `tinboard` itself. At the moment the tags suggestions only come from Pinboard, rather than from the combination of Pinboard and the local bookmarks -- improving this will need that the bookmark data be pulled out of the `Bookmarks` widget and into its own data structure that is outwith of anything related to the Textual application.

I'll do this in a followup PR at some point.