### PR TITLE
Decouple bookmark data downloading/loading/saving from the `Bookmarks` widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
 - Added a `--filter` command line argument.
 - Added a `add` command line command, which shows the bookmark addition
   screen "inline" in the terminal, allows adding a new bookmark, then exits.
+- Internal: changed the way that bookmarks are held and managed.
 
 ## v0.10.0
 

--- a/tinboard/app.py
+++ b/tinboard/app.py
@@ -15,7 +15,13 @@ from textual.binding import Binding
 
 ##############################################################################
 # Local imports.
-from .data import ExitStates, load_configuration, save_configuration, token_file
+from .data import (
+    Bookmarks,
+    ExitStates,
+    load_configuration,
+    save_configuration,
+    token_file,
+)
 from .pinboard import API, BookmarkData
 from .screens import BookmarkInput, Main, TokenInput
 from .widgets.filters import Filters
@@ -111,7 +117,10 @@ class Tinboard(App[ExitStates]):
                 # quick input. Note disabling the command palette too, which
                 # has problems with inline mode.
                 self.use_command_palette = False
-                self.push_screen(BookmarkInput(API(token)), callback=self.inline_add)
+                self.push_screen(
+                    BookmarkInput(API(token), known_tags=Bookmarks().load().tags),
+                    callback=self.inline_add,
+                )
             else:
                 # We're not in inline mode so we'll show the normal
                 # application screen.

--- a/tinboard/data/__init__.py
+++ b/tinboard/data/__init__.py
@@ -2,7 +2,7 @@
 
 ##############################################################################
 # Local imports.
-from .bookmarks import bookmarks_file
+from .bookmarks import Bookmarks, bookmarks_file
 from .config import load_configuration, save_configuration
 from .exit_states import ExitStates
 from .token import token_file
@@ -11,6 +11,7 @@ from .token import token_file
 # Exports.
 __all__ = [
     "bookmarks_file",
+    "Bookmarks",
     "ExitStates",
     "load_configuration",
     "save_configuration",

--- a/tinboard/data/bookmarks.py
+++ b/tinboard/data/bookmarks.py
@@ -2,10 +2,23 @@
 
 ##############################################################################
 # Python imports.
+from dataclasses import dataclass
+from datetime import datetime
+from json import JSONEncoder, dumps, loads
 from pathlib import Path
+from typing import Any, Iterator
+
+##############################################################################
+# pytz imports.
+from pytz import UTC
+
+##############################################################################
+# Backward-compatible typing.
+from typing_extensions import Self
 
 ##############################################################################
 # Local imports.
+from ..pinboard import API, BookmarkData
 from .locations import data_dir
 
 
@@ -17,6 +30,215 @@ def bookmarks_file() -> Path:
         The path to the bookmarks file.
     """
     return data_dir() / "bookmarks.json"
+
+
+##############################################################################
+class Bookmarks:
+    """Class that holds the local copy of all the bookmarks."""
+
+    def __init__(self) -> None:
+        """Initialise the bookmarks."""
+        super().__init__()
+        self._bookmarks: list[BookmarkData] = []
+        """The internal list of bookmarks."""
+        self._index: dict[str, int] = {}
+        """The index into the bookmarks."""
+        self._last_downloaded: datetime | None = None
+        """When the bookmarks were last downloaded."""
+
+    @property
+    def last_downloaded(self) -> datetime | None:
+        """The time the bookmarks were last downloaded, or `None` if not yet."""
+        return self._last_downloaded
+
+    def _reindex(self) -> Self:
+        """Reindex the bookmarks."""
+        self._index = {
+            bookmark.hash: index for index, bookmark in enumerate(self._bookmarks)
+        }
+        return self
+
+    def mark_downloaded(self) -> Self:
+        """Mark the bookmarks as having being downloaded at the time of calling."""
+        self._last_downloaded = datetime.now(UTC)
+        return self
+
+    async def download(self, api: API) -> Self:
+        """Download all available bookmarks from the server.
+
+        Args:
+            api: The API to download via.
+
+        Returns:
+            Self.
+        """
+        self._bookmarks = await api.all_bookmarks()
+        return self._reindex().mark_downloaded()
+
+    def _load_local_json(self, data: dict[str, Any]) -> Self:
+        """Load the bookmarks from the given JSON data.
+
+        Args:
+            data: The data to load.
+
+        Returns:
+            Self.
+        """
+        self._last_downloaded = datetime.fromisoformat(data["last_downloaded"])
+        self._bookmarks = [
+            BookmarkData.from_json(bookmark) for bookmark in data["bookmarks"]
+        ]
+        return self._reindex()
+
+    def load(self) -> Self:
+        """Load the bookmarks from the local file.
+
+        Returns:
+            Self.
+        """
+        if bookmarks_file().exists():
+            self._load_local_json(loads(bookmarks_file().read_text(encoding="utf-8")))
+        return self
+
+    class _Encoder(JSONEncoder):
+        """Encoder for turning the bookmarks into JSON data."""
+
+        def default(self, o: object) -> Any:
+            """Handle unknown values.
+
+            Args:
+                o: The object to handle.
+            """
+            return datetime.isoformat(o) if isinstance(o, datetime) else o
+
+    @property
+    def _as_local_json(self) -> dict[str, Any]:
+        """All the bookmarks as a JSON-friendly list."""
+        return {
+            "last_downloaded": None
+            if self._last_downloaded is None
+            else self._last_downloaded.isoformat(),
+            "bookmarks": [bookmark.as_json for bookmark in self._bookmarks],
+        }
+
+    def save(self) -> Self:
+        """Save the bookmarks to the local file.
+
+        Returns:
+            Self.
+        """
+        bookmarks_file().write_text(
+            dumps(self._as_local_json, indent=4, cls=self._Encoder), encoding="utf-8"
+        )
+        return self
+
+    def update_bookmark(self, bookmark: BookmarkData) -> Self:
+        """Update the bookmarks with the given bookmark data.
+
+        Args:
+            bookmark: The bookmark data to update with.
+
+        Returns:
+            Self.
+
+        Note:
+            If the `hash` of the bookmark is known, the existing bookmark
+            will be replaced with the new data. If the hash is unknown a
+            brand new bookmark will be added to the collection.
+        """
+        # If the bookmark is already known...
+        if (bookmark_index := self._index.get(bookmark.hash)) is not None:
+            # ...replace it.
+            self._bookmarks[bookmark_index] = bookmark
+        else:
+            # ...otherwise add it at the top of the list.
+            self._bookmarks.insert(0, bookmark)
+            self._reindex()
+        return self
+
+    def remove_bookmark(self, bookmark: BookmarkData) -> Self:
+        """Remove the given bookmark data.
+
+        Args:
+            bookmark: The bookmark to remove.
+
+        Returns:
+            Self.
+        """
+        del self._bookmarks[self._index[bookmark.hash]]
+        return self._reindex()
+
+    @dataclass
+    class Counts:
+        """The various bookmark counts."""
+
+        all: int = 0
+        """The count of all the bookmarks."""
+        unread: int = 0
+        """The count of unread bookmarks."""
+        read: int = 0
+        """The count of read bookmarks."""
+        private: int = 0
+        """The count of private bookmarks."""
+        public: int = 0
+        """The count of public bookmarks."""
+        untagged: int = 0
+        """The count of untagged bookmarks."""
+        tagged: int = 0
+        """The count of tagged bookmarks."""
+
+    @property
+    def counts(self) -> Counts:
+        """The various counts for the bookmarks."""
+        # TODO: cache this.
+        counts = self.Counts(all=len(self._bookmarks))
+        for bookmark in self._bookmarks:
+            if bookmark.to_read:
+                counts.unread += 1
+            else:
+                counts.read += 1
+            if bookmark.shared:
+                counts.public += 1
+            else:
+                counts.private += 1
+            if bookmark.tags:
+                counts.tagged += 1
+            else:
+                counts.untagged += 1
+        return counts
+
+    @property
+    def tags(self) -> list[str]:
+        """All known tags used in the bookmarks."""
+        tags: set[str] = set()
+        for bookmark in self._bookmarks:
+            tags |= set(tag for tag in bookmark.tag_list)
+        return sorted(list(tags), key=str.casefold)
+
+    def __len__(self) -> int:
+        """Returns the number of bookmarks."""
+        return len(self._bookmarks)
+
+    def __bool__(self) -> bool:
+        """`True` if there are bookmarks, `False` if not."""
+        return bool(len(self))
+
+    def __getitem__(self, index: str | int) -> BookmarkData:
+        """Get a bookmark.
+
+        Args:
+            index: Either the hash of the bookmark, or its integer index.
+
+        Returns:
+            The bookmark data.
+        """
+        if isinstance(index, str):
+            return self[self._index[index]]
+        return self._bookmarks[index]
+
+    def __iter__(self) -> Iterator[BookmarkData]:
+        """An iterator over the bookmarks."""
+        return iter(self._bookmarks)
 
 
 ### bookmarks.py ends here

--- a/tinboard/pinboard/__init__.py
+++ b/tinboard/pinboard/__init__.py
@@ -2,7 +2,8 @@
 
 ##############################################################################
 # Local imports.
-from .api import API, BookmarkData
+from .api import API
+from .bookmark_data import BookmarkData
 
 ##############################################################################
 # Exports.

--- a/tinboard/pinboard/api.py
+++ b/tinboard/pinboard/api.py
@@ -104,6 +104,11 @@ class BookmarkData:
         """The bookmark in JSON-friendly form."""
         return asdict(self)
 
+    @property
+    def tag_list(self) -> list[str]:
+        """The tags as a list of individual tags."""
+        return self.tags.split()
+
 
 ##############################################################################
 class API:

--- a/tinboard/pinboard/api.py
+++ b/tinboard/pinboard/api.py
@@ -2,13 +2,12 @@
 
 ##############################################################################
 # Python imports.
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import reduce
-from hashlib import md5
 from json import loads
 from operator import or_
-from typing import Any, Final
+from typing import Final
 
 ##############################################################################
 # HTTPX imports.
@@ -18,96 +17,10 @@ import httpx
 # pytz imports.
 from pytz import UTC
 
-
 ##############################################################################
-def parse_time(text: str) -> datetime:
-    """Parse a time from the Pinboard API.
-
-    Args:
-        text: The text version of the time to parse.
-
-    Returns:
-        The parsed time.
-
-    Pinboard returns times ending in a `Z`. Python doesn't seem capable of
-    parsing that. So we swap that for a `+00:00` and then parse.
-    """
-    return datetime.fromisoformat(
-        (text.removesuffix("Z") + "+00:00") if "Z" in text else text
-    )
-
-
-##############################################################################
-@dataclass
-class BookmarkData:
-    """Pinboard bookmark data."""
-
-    href: str
-    """The URL for the bookmark."""
-
-    description: str
-    """The description (AKA title) of the bookmark."""
-
-    extended: str
-    """The extended description of the bookmark."""
-
-    hash: str
-    """The hash for the bookmark."""
-
-    time: datetime
-    """The time of the bookmark's modification."""
-
-    shared: bool
-    """Is the bookmark shared with the public?"""
-
-    to_read: bool
-    """Is the bookmark unread?"""
-
-    tags: str
-    """The tags for the bookmark, space-separated."""
-
-    def __post_init__(self) -> None:
-        """Final initialisation of the bookmark data.
-
-        If `hash` is empty, one will be generated.
-        """
-        if not self.hash:
-            self.hash = md5(self.href.encode()).hexdigest()
-
-    @classmethod
-    def from_json(cls, data: dict[str, Any]) -> "BookmarkData":
-        """Create an instance of `BookmarkData` from JSON data.
-
-        Args:
-            data: The data to create the bookmark instance from.
-
-        Returns:
-            An instance of `BookmarkData`.
-        """
-
-        def boolify(value: str | bool) -> bool:
-            return value == "yes" if isinstance(value, str) else value
-
-        return cls(
-            href=data.get("href", ""),
-            description=data.get("description", ""),
-            extended=data.get("extended", ""),
-            hash=data.get("hash", ""),
-            time=parse_time(data.get("time", "")),
-            shared=boolify(data.get("shared", "")),
-            to_read=boolify(data.get("toread", "")),
-            tags=data.get("tags", ""),
-        )
-
-    @property
-    def as_json(self) -> dict[str, str]:
-        """The bookmark in JSON-friendly form."""
-        return asdict(self)
-
-    @property
-    def tag_list(self) -> list[str]:
-        """The tags as a list of individual tags."""
-        return self.tags.split()
+# Local imports.
+from .bookmark_data import BookmarkData
+from .parse_time import parse_time
 
 
 ##############################################################################

--- a/tinboard/pinboard/bookmark_data.py
+++ b/tinboard/pinboard/bookmark_data.py
@@ -84,5 +84,35 @@ class BookmarkData:
         """The tags as a list of individual tags."""
         return self.tags.split()
 
+    def is_tagged(self, *tags: str) -> bool:
+        """Is this bookmark tagged with the given tags?
+
+        Args:
+            tags: The tags to check for.
+
+        Returns:
+            `True` if the bookmark has all the tags, `False` if not.
+        """
+        return {tag.casefold() for tag in tags}.issubset(
+            {tag.casefold() for tag in self.tag_list}
+        )
+
+    def has_text(self, search_text: str) -> bool:
+        """Does the bookmark contain the given text?
+
+        Note that this is a case-insensitive test.
+
+        Args:
+            search_text: The text to search for.
+
+        Returns:
+            `True` if the text was found anywhere in the bookmark, `False`
+            if not.
+        """
+        return (
+            search_text.casefold()
+            in f"{self.description} {self.extended} {self.tags}".casefold()
+        )
+
 
 ### bookmark_data.py ends here

--- a/tinboard/pinboard/bookmark_data.py
+++ b/tinboard/pinboard/bookmark_data.py
@@ -84,6 +84,11 @@ class BookmarkData:
         """The tags as a list of individual tags."""
         return self.tags.split()
 
+    @property
+    def has_tags(self) -> bool:
+        """Does the bookmark have any tags?"""
+        return bool(self.tag_list)
+
     def is_tagged(self, *tags: str) -> bool:
         """Is this bookmark tagged with the given tags?
 

--- a/tinboard/pinboard/bookmark_data.py
+++ b/tinboard/pinboard/bookmark_data.py
@@ -1,0 +1,88 @@
+"""Provides a class for holding data on a bookmark."""
+
+##############################################################################
+# Python imports.
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from hashlib import md5
+from typing import Any
+
+##############################################################################
+# Local imports.
+from .parse_time import parse_time
+
+
+##############################################################################
+@dataclass
+class BookmarkData:
+    """Pinboard bookmark data."""
+
+    href: str
+    """The URL for the bookmark."""
+
+    description: str
+    """The description (AKA title) of the bookmark."""
+
+    extended: str
+    """The extended description of the bookmark."""
+
+    hash: str
+    """The hash for the bookmark."""
+
+    time: datetime
+    """The time of the bookmark's modification."""
+
+    shared: bool
+    """Is the bookmark shared with the public?"""
+
+    to_read: bool
+    """Is the bookmark unread?"""
+
+    tags: str
+    """The tags for the bookmark, space-separated."""
+
+    def __post_init__(self) -> None:
+        """Final initialisation of the bookmark data.
+
+        If `hash` is empty, one will be generated.
+        """
+        if not self.hash:
+            self.hash = md5(self.href.encode()).hexdigest()
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "BookmarkData":
+        """Create an instance of `BookmarkData` from JSON data.
+
+        Args:
+            data: The data to create the bookmark instance from.
+
+        Returns:
+            An instance of `BookmarkData`.
+        """
+
+        def boolify(value: str | bool) -> bool:
+            return value == "yes" if isinstance(value, str) else value
+
+        return cls(
+            href=data.get("href", ""),
+            description=data.get("description", ""),
+            extended=data.get("extended", ""),
+            hash=data.get("hash", ""),
+            time=parse_time(data.get("time", "")),
+            shared=boolify(data.get("shared", "")),
+            to_read=boolify(data.get("toread", "")),
+            tags=data.get("tags", ""),
+        )
+
+    @property
+    def as_json(self) -> dict[str, str]:
+        """The bookmark in JSON-friendly form."""
+        return asdict(self)
+
+    @property
+    def tag_list(self) -> list[str]:
+        """The tags as a list of individual tags."""
+        return self.tags.split()
+
+
+### bookmark_data.py ends here

--- a/tinboard/pinboard/bookmark_data.py
+++ b/tinboard/pinboard/bookmark_data.py
@@ -5,7 +5,7 @@
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from hashlib import md5
-from typing import Any
+from typing import Any, Callable
 
 ##############################################################################
 # Local imports.
@@ -118,6 +118,17 @@ class BookmarkData:
             search_text.casefold()
             in f"{self.description} {self.extended} {self.tags}".casefold()
         )
+
+    def is_all(self, *checks: Callable[["BookmarkData"], bool]) -> bool:
+        """Does this bookmark pass all the given tests?
+
+        Args:
+            checks: The checks to run against the bookmark.
+
+        Returns:
+            `True` if all tests pass, `False` if not.
+        """
+        return all(check(self) for check in checks)
 
 
 ### bookmark_data.py ends here

--- a/tinboard/pinboard/parse_time.py
+++ b/tinboard/pinboard/parse_time.py
@@ -1,0 +1,26 @@
+"""Provides a function for parsing time."""
+
+##############################################################################
+# Python imports.
+from datetime import datetime
+
+
+##############################################################################
+def parse_time(text: str) -> datetime:
+    """Parse a time from the Pinboard API.
+
+    Args:
+        text: The text version of the time to parse.
+
+    Returns:
+        The parsed time.
+
+    Pinboard returns times ending in a `Z`. Python doesn't seem capable of
+    parsing that. So we swap that for a `+00:00` and then parse.
+    """
+    return datetime.fromisoformat(
+        (text.removesuffix("Z") + "+00:00") if "Z" in text else text
+    )
+
+
+### parse_time.py ends here

--- a/tinboard/screens/main.py
+++ b/tinboard/screens/main.py
@@ -279,7 +279,7 @@ class Main(Screen[None]):
     @work
     async def maybe_redownload(self) -> None:
         """Redownload the bookmarks if they look newer on the server."""
-        if last_download := self.query_one(Bookmarks).last_downloaded:
+        if last_download := self.query_one(Bookmarks).bookmarks.last_downloaded:
             try:
                 latest_on_server = await self._api.last_update()
             except API.Error:
@@ -311,7 +311,7 @@ class Main(Screen[None]):
         # TODO: if getting the counts starts to look like it causes a wee
         # pause, perhaps calculate them from within a threaded worker.
         # Mostly though, so far, I'm not seeing any impact.
-        self.query_one(Filters).counts = bookmarks.counts
+        self.query_one(Filters).counts = bookmarks.bookmarks.counts
         bookmarks.focus()
 
     @on(Bookmarks.OptionHighlighted, "Bookmarks")
@@ -488,7 +488,9 @@ class Main(Screen[None]):
                 )
                 self.app.push_screen(
                     BookmarkInput(
-                        self._api, result, known_tags=self.query_one(Bookmarks).all_tags
+                        self._api,
+                        result,
+                        known_tags=self.query_one(Bookmarks).bookmarks.tags,
                     ),
                     callback=self.post_result,
                 )
@@ -522,7 +524,9 @@ class Main(Screen[None]):
     def add(self) -> None:
         """Add a new bookmark."""
         self.app.push_screen(
-            BookmarkInput(self._api, known_tags=self.query_one(Bookmarks).all_tags),
+            BookmarkInput(
+                self._api, known_tags=self.query_one(Bookmarks).bookmarks.tags
+            ),
             callback=self.post_result,
         )
 
@@ -536,7 +540,7 @@ class Main(Screen[None]):
                 BookmarkInput(
                     self._api,
                     bookmark.data,
-                    known_tags=self.query_one(Bookmarks).all_tags,
+                    known_tags=self.query_one(Bookmarks).bookmarks.tags,
                 ),
                 callback=self.post_result,
             )

--- a/tinboard/screens/main.py
+++ b/tinboard/screens/main.py
@@ -257,7 +257,7 @@ class Main(Screen[None]):
             the bookmarks will be overwritten.
         """
         try:
-            (await self.query_one(Bookmarks).download_all(self._api)).save()
+            await self.query_one(Bookmarks).download_all(self._api)
         except API.RequestError:
             self.app.bell()
             self.notify(

--- a/tinboard/widgets/bookmarks.py
+++ b/tinboard/widgets/bookmarks.py
@@ -94,18 +94,6 @@ class Bookmark(Option):
         # Combine them and add a rule afterwards.
         return Group(title, details, self.RULE)
 
-    @classmethod
-    def from_json(cls, data: dict[str, Any]) -> "Bookmark":
-        """Create a bookmark from some JSON data.
-
-        Args:
-            data: The data to create the bookmark from.
-
-        Returns:
-            The `Bookmark` instance.
-        """
-        return cls(BookmarkData.from_json(data))
-
     @property
     def data(self) -> BookmarkData:
         """The bookmark as the underlying bookmark data."""

--- a/tinboard/widgets/bookmarks.py
+++ b/tinboard/widgets/bookmarks.py
@@ -383,6 +383,14 @@ class Bookmarks(OptionListEx):
 
         Args:
             api: The API to download via.
+
+        Note:
+            As a side-effect of calling this method, the local copy of all
+            the bookmarks will be overwritten.
+
+        Raises:
+            API.RequestError: If there was an error downloading.
+            OSError: If there was an error saving the bookmarks.
         """
         self.bookmarks = (await LocalBookmarks().download(api)).save()
         return self

--- a/tinboard/widgets/bookmarks.py
+++ b/tinboard/widgets/bookmarks.py
@@ -150,9 +150,7 @@ class Bookmark(Option):
         Returns:
             The `Bookmark` instance.
         """
-        if "time" in data:
-            data["time"] = datetime.fromisoformat(data["time"])
-        return cls(BookmarkData(**data))
+        return cls(BookmarkData.from_json(data))
 
     @property
     def data(self) -> BookmarkData:

--- a/tinboard/widgets/bookmarks.py
+++ b/tinboard/widgets/bookmarks.py
@@ -3,7 +3,7 @@
 ##############################################################################
 # Python imports.
 from collections import Counter
-from typing import Any, Callable, Final, cast
+from typing import Callable, Final, cast
 from webbrowser import open as open_url
 
 ##############################################################################

--- a/tinboard/widgets/details.py
+++ b/tinboard/widgets/details.py
@@ -158,8 +158,11 @@ class Details(VerticalScroll):
                 f"The bookmark is {'[bold]public[/]' if self.bookmark.data.shared else '[dim]private[/]'}"
             )
             self.query_one(InlineTags).show(
-                [(tag, 1) for tag in sorted(self.bookmark.tags, key=str.casefold)]
-            ).set_class(not bool(self.bookmark.tags), "empty")
+                [
+                    (tag, 1)
+                    for tag in sorted(self.bookmark.data.tag_list, key=str.casefold)
+                ]
+            ).set_class(not self.bookmark.data.has_tags, "empty")
 
         finally:
             self.query("*").set_class(not bool(self.bookmark), "hidden")

--- a/tinboard/widgets/filters.py
+++ b/tinboard/widgets/filters.py
@@ -21,7 +21,7 @@ from textual.widgets.option_list import Option
 
 ##############################################################################
 # Local imports.
-from .bookmarks import Bookmarks
+from ..data import Bookmarks
 from .extended_option_list import OptionListEx
 
 


### PR DESCRIPTION
Implementing #39; this PR starts to move the low-level management of bookmarks (downloading, loading, saving, etc) out of the `Bookmarks` widget and into its own data structure. Until now the options within the widget were used as the store, this starts the migration of them out into their own class.

This also builds on #38 and allows for the full range of locally-known tags to be made available when doing an inline add.