### PR TITLE
Update Textual to v0.56.3

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -149,20 +149,20 @@
         },
         "textual": {
             "hashes": [
-                "sha256:4dac6401a4a1eaaf107a29560b28dc09d9a9867988c8fbb7763cfee4118e9664",
-                "sha256:b48052410d83b26944536511626ded9fa60e2bd7e4ca3d7e3b71865dba25a965"
+                "sha256:5d3efe7266aafc7b5a52ad622a155963fd22ec6043c769ecd7142490a3d9e17e",
+                "sha256:cff8ee993796fc02430aacd7f148894478ff7f3a6b77865da525a8965ecc0ccf"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==0.55.1"
+            "version": "==0.56.2"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.10.0"
+            "version": "==4.11.0"
         },
         "uc-micro-py": {
             "hashes": [
@@ -604,11 +604,11 @@
         },
         "jaraco.context": {
             "hashes": [
-                "sha256:4dad2404540b936a20acedec53355bdaea223acb88fd329fa6de9261c941566e",
-                "sha256:5d9e95ca0faa78943ed66f6bc658dd637430f16125d86988e77844c741ff2f11"
+                "sha256:3e16388f7da43d384a1a7cd3452e72e14732ac9fe459678773a3608a812bf266",
+                "sha256:c2f67165ce1f9be20f32f650f25d8edfc1646a8aeee48ae06fb35f90763576d2"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.3.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==5.3.0"
         },
         "jaraco.functools": {
             "hashes": [
@@ -1078,12 +1078,12 @@
         },
         "textual": {
             "hashes": [
-                "sha256:4dac6401a4a1eaaf107a29560b28dc09d9a9867988c8fbb7763cfee4118e9664",
-                "sha256:b48052410d83b26944536511626ded9fa60e2bd7e4ca3d7e3b71865dba25a965"
+                "sha256:5d3efe7266aafc7b5a52ad622a155963fd22ec6043c769ecd7142490a3d9e17e",
+                "sha256:cff8ee993796fc02430aacd7f148894478ff7f3a6b77865da525a8965ecc0ccf"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==0.55.1"
+            "version": "==0.56.2"
         },
         "textual-dev": {
             "hashes": [
@@ -1122,11 +1122,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.10.0"
+            "version": "==4.11.0"
         },
         "uc-micro-py": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -149,12 +149,12 @@
         },
         "textual": {
             "hashes": [
-                "sha256:5d3efe7266aafc7b5a52ad622a155963fd22ec6043c769ecd7142490a3d9e17e",
-                "sha256:cff8ee993796fc02430aacd7f148894478ff7f3a6b77865da525a8965ecc0ccf"
+                "sha256:9549a005a31658cd4dce7f73a247bc699b6173c74afc52c5dfdddb0afd4a67e2",
+                "sha256:bb876b16382b4a0b8d1e667055af28dad8d2a720f4298ec950e00d791b95b7ac"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==0.56.2"
+            "version": "==0.56.3"
         },
         "typing-extensions": {
             "hashes": [
@@ -1078,12 +1078,12 @@
         },
         "textual": {
             "hashes": [
-                "sha256:5d3efe7266aafc7b5a52ad622a155963fd22ec6043c769ecd7142490a3d9e17e",
-                "sha256:cff8ee993796fc02430aacd7f148894478ff7f3a6b77865da525a8965ecc0ccf"
+                "sha256:9549a005a31658cd4dce7f73a247bc699b6173c74afc52c5dfdddb0afd4a67e2",
+                "sha256:bb876b16382b4a0b8d1e667055af28dad8d2a720f4298ec950e00d791b95b7ac"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==0.56.2"
+            "version": "==0.56.3"
         },
         "textual-dev": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 platforms = any
 include_package_data = True
 install_requires =
-    textual>=0.55.1
+    textual>=0.56.2
     xdg-base-dirs>=6.0.0
     pytz
     humanize>=4.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 platforms = any
 include_package_data = True
 install_requires =
-    textual>=0.56.2
+    textual>=0.56.3
     xdg-base-dirs>=6.0.0
     pytz
     humanize>=4.8.0


### PR DESCRIPTION
Having upgraded to Textual v0.56.2 the inline bookmark add screen became super laggy and wasn't updating properly; reported as https://github.com/Textualize/textual/issues/4403.  https://github.com/Textualize/textual/commit/7aebd25d4b3e31f46c74761d6a98030fff8424be has been pushed and released to address this.

I'm still finding that, in kitty at least, there's still some weird lag with `Input` widgets when working inline, but it's now more subtle. As such I'm bumping to this version of Textual and will work from there.