### PR TITLE
Correct the reading of the local copy of the to-read flag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Tinboard ChangeLog
 
+## v0.11.1
+
+**Released: 2024-04-09**
+
+- Fix an issue introduced in v0.11.0 where the "to read" flag wasn't being
+  correctly read back in from the local copy of the bookmarks.
+
 ## v0.11.0
 
 **Released: 2024-04-09**

--- a/tinboard/__init__.py
+++ b/tinboard/__init__.py
@@ -7,7 +7,7 @@ __copyright__ = "Copyright 2023-2024, Dave Pearson"
 __credits__ = ["Dave Pearson"]
 __maintainer__ = "Dave Pearson"
 __email__ = "davep@davep.org"
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 __licence__ = "GPLv3+"
 
 ##############################################################################

--- a/tinboard/pinboard/bookmark_data.py
+++ b/tinboard/pinboard/bookmark_data.py
@@ -63,6 +63,11 @@ class BookmarkData:
         def boolify(value: str | bool) -> bool:
             return value == "yes" if isinstance(value, str) else value
 
+        # An accident of how this developed means that the Pinboard API
+        # calls this `toread`, but I locally call it `to_read`, and I ended
+        # up using the same code to pull the data back from JSON. So...
+        to_read = "to_read" if "to_read" in data else "toread"
+
         return cls(
             href=data.get("href", ""),
             description=data.get("description", ""),
@@ -70,7 +75,7 @@ class BookmarkData:
             hash=data.get("hash", ""),
             time=parse_time(data.get("time", "")),
             shared=boolify(data.get("shared", "")),
-            to_read=boolify(data.get("toread", "")),
+            to_read=boolify(data.get(to_read, "")),
             tags=data.get("tags", ""),
         )
 

--- a/tinboard/pinboard/bookmark_data.py
+++ b/tinboard/pinboard/bookmark_data.py
@@ -66,7 +66,8 @@ class BookmarkData:
         # An accident of how this developed means that the Pinboard API
         # calls this `toread`, but I locally call it `to_read`, and I ended
         # up using the same code to pull the data back from JSON. So...
-        to_read = "to_read" if "to_read" in data else "toread"
+        if (to_read := "to_read") not in data:
+            to_read = "toread"
 
         return cls(
             href=data.get("href", ""),


### PR DESCRIPTION
In consolidating the code that pulls data from the API and also from the local copy of the data, I managed to lose the reading of the local version of the "to read" flag[^1]. This PR fixes this.

[^1]: The Pinboard API calls it `toread`, locally I had gone with `to_read` because it's easier on the eye.