### PR TITLE
Align the content of TextArea with Input

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - When copying a bookmark to the clipboard, a best effort is now made to
   ensure it'll also make it over a remote connection.
+- Small cosmetic change to the bookmark input dialog to properly line up the
+  description content with the rest of the inputs.
 
 ## v0.12.0
 

--- a/tinboard/screens/bookmark_input.py
+++ b/tinboard/screens/bookmark_input.py
@@ -51,6 +51,10 @@ class BookmarkInput(ModalScreen[BookmarkData | None]):
             }
         }
 
+        TextArea {
+            padding: 0 2 0 2;
+        }
+
         #description {
             height: 10;
         }


### PR DESCRIPTION
In the bookmark editor a `TextArea` is used as a multi-line `Input`, but by default a Textual `TextArea` doesn't have the same padding as an `Input`. This brings it into line with `Input`.